### PR TITLE
Define DLT_LINUX_SLL2

### DIFF
--- a/linktypes/LINKTYPE_LINUX_SLL2.html
+++ b/linktypes/LINKTYPE_LINUX_SLL2.html
@@ -1,0 +1,153 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!--
+Created by       : Luis MartinGarcia <http://www.aldabaknocking.com>
+Original design  : "Collaboration" by Free CSS Templates <http://www.freecsstemplates.org>
+Original license : Creative Commons Attribution 2.5 License
+-->
+<html>
+
+    <!-- HEAD -->
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+        <title>LINKTYPE_LINUX_SLL2 | TCPDUMP/LIBPCAP public repository</title>
+        <meta name="keywords" content="tcpdump, libpcap, pcap, packet capture, sniffer, security, eavesdrop">
+        <meta name="description" content="Web site of Tcpdump and Libpcap">
+		<meta name="DC.publisher" content="Tcpdump">
+		<meta name="DC.publisher.url" content="http://www.tcpdump.org">
+		<meta name="DC.title" content="Tcpdump/Libpcap public repository">
+		<meta name="DC.identifier" content="http://www.tcpdump.org">
+		<meta name="DC.date.created" scheme="WTN8601" content="2014-12-25T20:17:22">
+		<meta name="DC.creator" content="tcpdump">
+		<meta name="DC.rights.rightsHolder" content="tcpdump">
+		<meta name="DC.language" content="en" scheme="rfc1766">
+        <link href="../style.css" rel="stylesheet" type="text/css" media="screen">
+        <link rel="canonical" href="http://www.tcpdump.org">
+    </head>
+    <!-- END OF HTML HEAD -->
+
+    <!-- BODY -->
+    <body>
+
+        <!-- TOP MENU -->
+        <div id="menu">
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../index.html#source">Source</a></li>
+                <li><a href="../index.html#latest-release">Downloads</a></li>
+                <li><a href="../index.html#mailing-lists">Mailing lists</a></li>
+                <li><a href="../index.html#contribute">Contribute</a></li>
+                <li><a href="../related.html">Related Projects</a></li>
+                <li><a href="../linktypes.html">Link-Layer Header Types</a></li>
+            </ul>
+        </div>
+        <!-- END OF TOP MENU -->
+
+        <!-- PAGE HEADER -->
+        <div id="splash">
+            <br><img src="../images/logo.png" alt="">
+        </div>
+        <div id="logo">
+            <hr>
+        </div>
+        <!-- END OF PAGE HEADER -->
+
+        <!-- PAGE CONTENTS -->
+        <div id="page">
+
+          <!-- Start of LINKTYPE_LINUX_SLL2 section -->
+          <div class="post">
+            <h2 class="title">
+                <a name="intro">LINKTYPE_LINUX_SLL2</a>
+            </h2>
+            <div class="entry">
+                <h3>Packet structure</h3>
+<pre>
++---------------------------+
+|        Protocol type      |
+|         (2 Octets)        |
++---------------------------+
+|       Interface index     |
+|         (4 Octets)        |
++---------------------------+
+|        ARPHRD_ type       |
+|         (2 Octets)        |
++---------------------------+
+|         Packet type       |
+|         (1 Octet)         |
++---------------------------+
+| Link-layer address length |
+|         (1 Octets)        |
++---------------------------+
+|    Link-layer address     |
+|         (8 Octets)        |
++---------------------------+
+|           Payload         |
+.                           .
+.                           .
+.                           .
+</pre>
+
+                <h3>Description</h3>
+<p>The protocol type field is in network byte order; it contains an
+Ethernet protocol type, or one of:
+</p>
+<ul>
+<li>1, if the frame is a Novell 802.3 frame without an 802.2 LLC
+header;</li>
+<li>4, if the frame begins with an 802.2 LLC header.</li>
+</ul>
+</p>
+<p>
+The interface index field is in network byte order and contains the
+1-based index of the interface on which the packet was observed.
+</p>
+<p>
+The ARPHRD_ type field is in network byte order; it contains a Linux
+ARPHRD_ value for the link-layer device type.
+</p>
+<p>
+The packet type field contains a value that is one of:
+</p>
+<ul>
+<li>0, if the packet was specifically sent to us by somebody else;</li>
+<li>1, if the packet was broadcast by somebody else;</li>
+<li>2, if the packet was multicast, but not broadcast, by somebody
+else;</li>
+<li>3, if the packet was sent to somebody else by somebody else;</li>
+<li>4, if the packet was sent by us.</li>
+</ul>
+<p>
+The link-layer address length field contains the length of the link-layer
+address of the sender of the packet.  That length could be zero.
+</p>
+<p>
+The link-layer address field contains the link-layer address of the
+sender of the packet; the number of bytes of that field that are
+meaningful is specified by the link-layer address length field.  If
+there are more than 8 bytes, only the first 8 bytes are present, and
+if there are fewer than 8 bytes, there are padding bytes after the
+address to pad the field to 8 bytes.
+</p>
+            </div>
+            <!-- End of LINKTYPE_LINUX_SLL2 section -->
+          </div>
+        </div>
+        <!-- END OF PAGE CONTENTS -->
+
+        <!-- FOOTER -->
+        <div id="footer">
+            <p>
+                (c) 2010-2014 Tcpdump/Libpcap. Designed by
+                <a href="http://www.aldabaknocking.com/">Luis MartinGarcia</a>;
+                based on a template by <a href="http://www.freecsstemplates.org/">
+                Free CSS Templates</a>.
+                <a href="http://validator.w3.org/check?uri=referer">[Valid XHTML
+                1.0]</a> <a href="http://jigsaw.w3.org/css-validator/check/referer">
+                [Valid CSS]</a>
+            </p>
+        </div>
+        <!-- END OF FOOTER -->
+        
+    </body>
+    <!-- END OF HTML BODY -->
+</html>

--- a/linktypes/LINKTYPE_LINUX_SLL2.html
+++ b/linktypes/LINKTYPE_LINUX_SLL2.html
@@ -98,8 +98,8 @@ header;</li>
 </ul>
 </p>
 <p>
-The interface index field is in network byte order and contains the
-1-based index of the interface on which the packet was observed.
+The interface index field is a signed integer in network byte order and
+contains the 1-based index of the interface on which the packet was observed.
 </p>
 <p>
 The ARPHRD_ type field is in network byte order; it contains a Linux


### PR DESCRIPTION
As required in order to be able to dump both interface index and packet direction. Header structure copied from the current form of 'struct sockaddr_sll' on Linux, a very early version of which was used by the original LINKTYPE_LINUX_SLL but Linux's actual structure has changed much since then.

Required for https://github.com/the-tcpdump-group/libpcap/issues/127