### PR TITLE
Fix typo 'tcp-act' in manpages

### DIFF
--- a/manpages/tcpdump.1.html
+++ b/manpages/tcpdump.1.html
@@ -1834,7 +1834,7 @@ Some offsets and field values may be expressed as names
 rather than as numeric values. For example tcp[13] may
 be replaced with tcp[tcpflags]. The following TCP flag
 field values are also available: tcp-fin, tcp-syn, tcp-rst,
-tcp-push, tcp-act, tcp-urg.
+tcp-push, tcp-ack, tcp-urg.
 <P>
 
 This can be demonstrated as:

--- a/manpages/tcpdump.1.txt
+++ b/manpages/tcpdump.1.txt
@@ -938,7 +938,7 @@ OUTPUT FORMAT
        Some offsets and field values may be expressed as names rather than  as
        numeric values. For example tcp[13] may be replaced with tcp[tcpflags].
        The following TCP flag field values are also available:  tcp-fin,  tcp-
-       syn, tcp-rst, tcp-push, tcp-act, tcp-urg.
+       syn, tcp-rst, tcp-push, tcp-ack, tcp-urg.
 
        This can be demonstrated as:
                    tcpdump -i xl0 'tcp[tcpflags] & tcp-push != 0'


### PR DESCRIPTION
I found a typo in `man 8 tcpdump` on Linux. I'm not sure this is the right place to send this kind of patch, though.