### PR TITLE
Add DLT_LINUX_SLL2 in linktypes.html

### DIFF
--- a/linktypes.html
+++ b/linktypes.html
@@ -742,7 +742,7 @@ as the payload.
 pseudo-header</a>, followed by the payload, which is typically the
 PHYPayload from the <a
 href="https://www.lora-alliance.org/lorawan-for-developers">LoRaWan
-specification</a>. 
+specification</a>.
 </td>
                 <tr valign=top>
 <td>LINKTYPE_VSOCK<td>271<td>DLT_VSOCK<td>
@@ -771,9 +771,13 @@ field.
                 <tr valign=top>
 <td>LINKTYPE_DISPLAYPORT_AUX</td><td>275</td><td>DLT_DISPLAYPORT_AUX</td><td>
 DisplayPort AUX channel monitoring data as specified by VESA
-DisplayPort(DP) Standard preceeded by a 
+DisplayPort(DP) Standard preceeded by a
 <a href="linktypes/LINKTYPE_DISPLAYPORT_AUX.html">pseudo-header</a>.
 </td>
+                <tr valign=top>
+<td>LINKTYPE_LINUX_SLL2<td>276<td>DLT_LINUX_SLL2<td>
+<a href="linktypes/LINKTYPE_LINUX_SLL2.html">Linux "cooked" capture
+encapsulation v2</a>.
 </tr>
 
 


### PR DESCRIPTION
with linktype value 276.

Implements: GH the-tcpdump-group/libpcap#127

Signed-off-by: Petr Vorel <pvorel@suse.cz>