### PR TITLE
Modernize LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR

### DIFF
--- a/htmlsrc/linktypes/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html
+++ b/htmlsrc/linktypes/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html
@@ -1,11 +1,12 @@
 <div class="post">
-<h2 class="title"><a name="intro">LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR</a></h2>
-<a href="http://www.whiterocker.com/bt/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html">(orig)</a><br>
-<div class="entry">
+	<h2 class="title">
+		<a name="intro">LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR</a>
+	</h2>
 
-<h3>Packet structure</h3>
-<pre>
-+---------------------------+
+	<div class="entry">
+
+		<h3>Packet structure</h3>
+		<pre>+---------------------------+
 |         RF Channel        |
 |         (1 Octet)         |
 +---------------------------+
@@ -27,25 +28,90 @@
 |  LE Packet (no preamble)  |
 .                           .
 .                           .
-.                           .
-</pre>
+.                           .</pre>
 
-<h3>Description</h3>
-<p>All multi-octet fields are expressed in little-endian format.  Fields with a corresponding Flags bit are only considered valid when the bit is set.</p><p>The RF Channel field ranges 0 to 39.  It reflects the value described in the Bluetooth specification Volume 6, Part A, Section 2.</p><p>The Signal Power and Noise Power fields are signed integers expressing values in dBm.</p><p>The Access Address Offenses field is an unsigned integer indicating the number of deviations from the valid access address that led to the packet capture.  Access addresses are interpreted as described in Bluetooth specification Volume 6, Part B, Section 2.1.2.</p><p>The Reference Access Address field corresponds to the Access Address configured into the capture tool that led to the capture of this packet.</p><p>The Flags field represents packed bits defined as follows.
-<ul>
-<li>0x0001 indicates the LE Packet is de-whitened</li>
-<li>0x0002 indicates the Signal Power field is valid</li>
-<li>0x0004 indicates the Noise Power field is valid</li>
-<li>0x0008 indicates the LE Packet is decrypted</li>
-<li>0x0010 indicates the Reference Access Address is valid and led to this packet being captured</li>
-<li>0x0020 indicates the Access Address Offenses field contains valid data</li>
-<li>0x0040 indicates the RF Channel field is subject to aliasing</li>
-<li>0x0400 indicates the CRC portion of the LE Packet was checked</li>
-<li>0x0800 indicates the CRC portion of the LE Packet passed its check</li>
-<li>0x1000 indicates the MIC portion of the decrypted LE Packet was checked</li>
-<li>0x2000 indicates the MIC portion of the decrypted LE Packet passed its check</li>
-</ul>
-All other bit positions of the Flags field are reserved and must be zero.
-</p><p>The LE Packet follows the previous fields, and is formatted as detailed in Bluetooth specification Volume 6, Part B, Section 2, but does not include the preamble.  All multi-octet values in the LE Packet are always expressed in little-endian format, as is the normal Bluetooth practice.</p>
-</div>
+		<h3>Description</h3>
+
+		<p>All multi-octet fields are expressed in little-endian format. Fields with a corresponding Flags
+		bit are only considered valid when the bit is set.</p>
+
+		<p>The RF Channel field ranges 0 to 39. It reflects the value described in the Bluetooth Core
+		Specification v5.2, Volume 6, Part A, Section 2.</p>
+
+		<p>The Signal Power and Noise Power fields are signed integers expressing values in dBm.</p>
+
+		<p>The Access Address Offenses field is an unsigned integer indicating the number of deviations
+		from the valid access address that led to the packet capture. Access addresses are interpreted as
+		described in the Bluetooth Core Specification v5.2, Volume 6, Part B, Section 2.1.2.</p>
+
+		<p>The Reference Access Address field corresponds to the Access Address configured into the capture
+		tool that led to the capture of this packet.</p>
+
+		<p>The Flags field represents packed bits defined as follows:</p>
+		<ul>
+			<li>0x0001 indicates the LE Packet is de-whitened</li>
+			<li>0x0002 indicates the Signal Power field is valid</li>
+			<li>0x0004 indicates the Noise Power field is valid</li>
+			<li>0x0008 indicates the LE Packet is decrypted</li>
+			<li>0x0010 indicates the Reference Access Address is valid and led to this packet being captured</li>
+			<li>0x0020 indicates the Access Address Offenses field contains valid data</li>
+			<li>0x0040 indicates the RF Channel field is subject to aliasing</li>
+			<li>0x0380 is an integer bit field indicating the LE Packet PDU type</li>
+			<li>0x0400 indicates the CRC portion of the LE Packet was checked</li>
+			<li>0x0800 indicates the CRC portion of the LE Packet passed its check</li>
+			<li>0x3000 is a PDU type dependent field</li>
+			<li>0xC000 is an integer bit field indicating the LE PHY mode</li>
+		</ul>
+
+		<p>The PDU types indicated by flag bit field 0x0380 are defined as follows:</p>
+		<ol start="0">
+			<li>Advertising or Data (Unspecified Direction)</li>
+			<li>Auxiliary Advertising</li>
+			<li>Data, Master to Slave</li>
+			<li>Data, Slave to Master</li>
+			<li>Connected Isochronous, Master to Slave</li>
+			<li>Connected Isochronous, Slave to Master</li>
+			<li>Broadcast Isochronous</li>
+			<li>Reserved for Future Use</li>
+		</ol>
+
+		<p>For PDU types other than type 1 (auxiliary advertising), the PDU type dependent field
+		(using flag bits 0x3000) indicates the checked status of the MIC portion of the decrypted
+		packet:</p>
+		<ul>
+			<li>0x1000 indicates the MIC portion of the decrypted LE Packet was checked</li>
+			<li>0x2000 indicates the MIC portion of the decrypted LE Packet passed its check</li>
+		</ul>
+
+		<p>For PDU type 1 (auxiliary advertising), the PDU type dependent field (using flag bits
+		0x3000) is an integer bit field indicating the auxiliary advertisement type:</p>
+		<ol start="0">
+			<li>AUX_ADV_IND</li>
+			<li>AUX_CHAIN_IND</li>
+			<li>AUX_SYNC_IND</li>
+			<li>AUX_SCAN_RSP</li>
+		</ol>
+
+		<p>The LE PHY modes indicated by flag bit field 0xC000 are defined as follows:</p>
+		<ol start="0">
+			<li>LE 1M</li>
+			<li>LE 2M</li>
+			<li>LE Coded</li>
+			<li>Reserved for Future Use</li>
+		</ol>
+
+		<p>The LE Packet field follows the previous fields. All multi-octet values in the LE Packet are
+		always expressed in little-endian format, as is the normal Bluetooth practice.</p>
+
+		<p>For packets using the LE Uncoded PHYs (LE 1M PHY and LE 2M PHY) as defined in the Bluetooth
+		Core Specification v5.2, Volume 6, Part B, Section 2.1, the LE Packet is represented as the four-octet
+		access address, immediately followed by the PDU and CRC; it does not include the preamble.</p>
+
+		<p>For packets using the LE Coded PHY as defined in the Bluetooth Core Specification v5.2, Volume 6,
+		Part B, Section 2.2, the LE Packet is represented as the four-octet access address, followed by the
+		Coding Indicator (CI), stored in a one-octet field with the lower 2 bits containing the CI value,
+		immediately followed by the PDU and the CRC; it does not include the preamble. Packets using the
+		LE Coded PHY are represented in an uncoded form, so the TERM1 and TERM2 coding terminators are not
+		included in the LE packet field.</p>
+	</div>
 </div>

--- a/linktypes/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html
+++ b/linktypes/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html
@@ -55,13 +55,14 @@ Original license : Creative Commons Attribution 2.5 License
         <div id="page">
 
 <div class="post">
-<h2 class="title"><a name="intro">LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR</a></h2>
-<a href="http://www.whiterocker.com/bt/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html">(orig)</a><br>
-<div class="entry">
+	<h2 class="title">
+		<a name="intro">LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR</a>
+	</h2>
 
-<h3>Packet structure</h3>
-<pre>
-+---------------------------+
+	<div class="entry">
+
+		<h3>Packet structure</h3>
+		<pre>+---------------------------+
 |         RF Channel        |
 |         (1 Octet)         |
 +---------------------------+
@@ -83,27 +84,92 @@ Original license : Creative Commons Attribution 2.5 License
 |  LE Packet (no preamble)  |
 .                           .
 .                           .
-.                           .
-</pre>
+.                           .</pre>
 
-<h3>Description</h3>
-<p>All multi-octet fields are expressed in little-endian format.  Fields with a corresponding Flags bit are only considered valid when the bit is set.</p><p>The RF Channel field ranges 0 to 39.  It reflects the value described in the Bluetooth specification Volume 6, Part A, Section 2.</p><p>The Signal Power and Noise Power fields are signed integers expressing values in dBm.</p><p>The Access Address Offenses field is an unsigned integer indicating the number of deviations from the valid access address that led to the packet capture.  Access addresses are interpreted as described in Bluetooth specification Volume 6, Part B, Section 2.1.2.</p><p>The Reference Access Address field corresponds to the Access Address configured into the capture tool that led to the capture of this packet.</p><p>The Flags field represents packed bits defined as follows.
-<ul>
-<li>0x0001 indicates the LE Packet is de-whitened</li>
-<li>0x0002 indicates the Signal Power field is valid</li>
-<li>0x0004 indicates the Noise Power field is valid</li>
-<li>0x0008 indicates the LE Packet is decrypted</li>
-<li>0x0010 indicates the Reference Access Address is valid and led to this packet being captured</li>
-<li>0x0020 indicates the Access Address Offenses field contains valid data</li>
-<li>0x0040 indicates the RF Channel field is subject to aliasing</li>
-<li>0x0400 indicates the CRC portion of the LE Packet was checked</li>
-<li>0x0800 indicates the CRC portion of the LE Packet passed its check</li>
-<li>0x1000 indicates the MIC portion of the decrypted LE Packet was checked</li>
-<li>0x2000 indicates the MIC portion of the decrypted LE Packet passed its check</li>
-</ul>
-All other bit positions of the Flags field are reserved and must be zero.
-</p><p>The LE Packet follows the previous fields, and is formatted as detailed in Bluetooth specification Volume 6, Part B, Section 2, but does not include the preamble.  All multi-octet values in the LE Packet are always expressed in little-endian format, as is the normal Bluetooth practice.</p>
-</div>
+		<h3>Description</h3>
+
+		<p>All multi-octet fields are expressed in little-endian format. Fields with a corresponding Flags
+		bit are only considered valid when the bit is set.</p>
+
+		<p>The RF Channel field ranges 0 to 39. It reflects the value described in the Bluetooth Core
+		Specification v5.2, Volume 6, Part A, Section 2.</p>
+
+		<p>The Signal Power and Noise Power fields are signed integers expressing values in dBm.</p>
+
+		<p>The Access Address Offenses field is an unsigned integer indicating the number of deviations
+		from the valid access address that led to the packet capture. Access addresses are interpreted as
+		described in the Bluetooth Core Specification v5.2, Volume 6, Part B, Section 2.1.2.</p>
+
+		<p>The Reference Access Address field corresponds to the Access Address configured into the capture
+		tool that led to the capture of this packet.</p>
+
+		<p>The Flags field represents packed bits defined as follows:</p>
+		<ul>
+			<li>0x0001 indicates the LE Packet is de-whitened</li>
+			<li>0x0002 indicates the Signal Power field is valid</li>
+			<li>0x0004 indicates the Noise Power field is valid</li>
+			<li>0x0008 indicates the LE Packet is decrypted</li>
+			<li>0x0010 indicates the Reference Access Address is valid and led to this packet being captured</li>
+			<li>0x0020 indicates the Access Address Offenses field contains valid data</li>
+			<li>0x0040 indicates the RF Channel field is subject to aliasing</li>
+			<li>0x0380 is an integer bit field indicating the LE Packet PDU type</li>
+			<li>0x0400 indicates the CRC portion of the LE Packet was checked</li>
+			<li>0x0800 indicates the CRC portion of the LE Packet passed its check</li>
+			<li>0x3000 is a PDU type dependent field</li>
+			<li>0xC000 is an integer bit field indicating the LE PHY mode</li>
+		</ul>
+
+		<p>The PDU types indicated by flag bit field 0x0380 are defined as follows:</p>
+		<ol start="0">
+			<li>Advertising or Data (Unspecified Direction)</li>
+			<li>Auxiliary Advertising</li>
+			<li>Data, Master to Slave</li>
+			<li>Data, Slave to Master</li>
+			<li>Connected Isochronous, Master to Slave</li>
+			<li>Connected Isochronous, Slave to Master</li>
+			<li>Broadcast Isochronous</li>
+			<li>Reserved for Future Use</li>
+		</ol>
+
+		<p>For PDU types other than type 1 (auxiliary advertising), the PDU type dependent field
+		(using flag bits 0x3000) indicates the checked status of the MIC portion of the decrypted
+		packet:</p>
+		<ul>
+			<li>0x1000 indicates the MIC portion of the decrypted LE Packet was checked</li>
+			<li>0x2000 indicates the MIC portion of the decrypted LE Packet passed its check</li>
+		</ul>
+
+		<p>For PDU type 1 (auxiliary advertising), the PDU type dependent field (using flag bits
+		0x3000) is an integer bit field indicating the auxiliary advertisement type:</p>
+		<ol start="0">
+			<li>AUX_ADV_IND</li>
+			<li>AUX_CHAIN_IND</li>
+			<li>AUX_SYNC_IND</li>
+			<li>AUX_SCAN_RSP</li>
+		</ol>
+
+		<p>The LE PHY modes indicated by flag bit field 0xC000 are defined as follows:</p>
+		<ol start="0">
+			<li>LE 1M</li>
+			<li>LE 2M</li>
+			<li>LE Coded</li>
+			<li>Reserved for Future Use</li>
+		</ol>
+
+		<p>The LE Packet field follows the previous fields. All multi-octet values in the LE Packet are
+		always expressed in little-endian format, as is the normal Bluetooth practice.</p>
+
+		<p>For packets using the LE Uncoded PHYs (LE 1M PHY and LE 2M PHY) as defined in the Bluetooth
+		Core Specification v5.2, Volume 6, Part B, Section 2.1, the LE Packet is represented as the four-octet
+		access address, immediately followed by the PDU and CRC; it does not include the preamble.</p>
+
+		<p>For packets using the LE Coded PHY as defined in the Bluetooth Core Specification v5.2, Volume 6,
+		Part B, Section 2.2, the LE Packet is represented as the four-octet access address, followed by the
+		Coding Indicator (CI), stored in a one-octet field with the lower 2 bits containing the CI value,
+		immediately followed by the PDU and the CRC; it does not include the preamble. Packets using the
+		LE Coded PHY are represented in an uncoded form, so the TERM1 and TERM2 coding terminators are not
+		included in the LE packet field.</p>
+	</div>
 </div>
         </div>
         <!-- END OF PAGE CONTENTS -->


### PR DESCRIPTION
Introduce new meanings to previously RFU flag bits to support new features in Bluetooth 5, as discussed in the tcpdump-workers mailing list. New specification developed in consultation with Joakim Andersson, Guy Harris, and Mike Ryan.