### PR TITLE
Add speed specific USB 2.0/1.1/1.0 linktypes

### DIFF
--- a/htmlsrc/linktypes.html
+++ b/htmlsrc/linktypes.html
@@ -1594,6 +1594,7 @@ USB 2.0, 1.1, or 1.0 packet, beginning with a PID, as described by
 Chapter 8 "Protocol Layer" of the <a class=away
 href="https://www.usb.org/document-library/usb-20-specification">the
 Universal Serial Bus Specification Revision 2.0</a>.
+Deprecated in favor of speed specfic USB 2.0, 1.1, or 1.0 linktypes.
 </td>
 </tr>
 
@@ -1629,6 +1630,42 @@ by DSR.
 <a class=away href="https://cloud.dsr-corporation.com/index.php/s/3isHzaNTTgtJebn">ZBOSS
  NCP protocol</a>, beginning with a
 <a href="linktypes/LINKTYPE_ZBOSS_NCP.html">header</a>.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_USB_2_0_LOW_SPEED</td>
+<td class="number">293</td>
+<td class="symbol">DLT_USB_2_0_LOW_SPEED</td>
+<td>
+Low-Speed USB 2.0, 1.1, or 1.0 packet, beginning with a PID, as described by
+Chapter 8 "Protocol Layer" of the <a class=away
+href="https://www.usb.org/document-library/usb-20-specification">the
+Universal Serial Bus Specification Revision 2.0</a>.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_USB_2_0_FULL_SPEED</td>
+<td class="number">294</td>
+<td class="symbol">DLT_USB_2_0_FULL_SPEED</td>
+<td>
+Full-Speed USB 2.0, 1.1, or 1.0 packet, beginning with a PID, as described by
+Chapter 8 "Protocol Layer" of the <a class=away
+href="https://www.usb.org/document-library/usb-20-specification">the
+Universal Serial Bus Specification Revision 2.0</a>.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_USB_2_0_HIGH_SPEED</td>
+<td class="number">295</td>
+<td class="symbol">DLT_USB_2_0_HIGH_SPEED</td>
+<td>
+High-Speed USB 2.0 packet, beginning with a PID, as described by
+Chapter 8 "Protocol Layer" of the <a class=away
+href="https://www.usb.org/document-library/usb-20-specification">the
+Universal Serial Bus Specification Revision 2.0</a>.
 </td>
 </tr>
               </table>

--- a/linktypes.html
+++ b/linktypes.html
@@ -1643,6 +1643,7 @@ USB 2.0, 1.1, or 1.0 packet, beginning with a PID, as described by
 Chapter 8 "Protocol Layer" of the <a class=away
 href="https://www.usb.org/document-library/usb-20-specification">the
 Universal Serial Bus Specification Revision 2.0</a>.
+Deprecated in favor of speed specfic USB 2.0, 1.1, or 1.0 linktypes.
 </td>
 </tr>
 
@@ -1678,6 +1679,42 @@ by DSR.
 <a class=away href="https://cloud.dsr-corporation.com/index.php/s/3isHzaNTTgtJebn">ZBOSS
  NCP protocol</a>, beginning with a
 <a href="linktypes/LINKTYPE_ZBOSS_NCP.html">header</a>.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_USB_2_0_LOW_SPEED</td>
+<td class="number">293</td>
+<td class="symbol">DLT_USB_2_0_LOW_SPEED</td>
+<td>
+Low-Speed USB 2.0, 1.1, or 1.0 packet, beginning with a PID, as described by
+Chapter 8 "Protocol Layer" of the <a class=away
+href="https://www.usb.org/document-library/usb-20-specification">the
+Universal Serial Bus Specification Revision 2.0</a>.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_USB_2_0_FULL_SPEED</td>
+<td class="number">294</td>
+<td class="symbol">DLT_USB_2_0_FULL_SPEED</td>
+<td>
+Full-Speed USB 2.0, 1.1, or 1.0 packet, beginning with a PID, as described by
+Chapter 8 "Protocol Layer" of the <a class=away
+href="https://www.usb.org/document-library/usb-20-specification">the
+Universal Serial Bus Specification Revision 2.0</a>.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_USB_2_0_HIGH_SPEED</td>
+<td class="number">295</td>
+<td class="symbol">DLT_USB_2_0_HIGH_SPEED</td>
+<td>
+High-Speed USB 2.0 packet, beginning with a PID, as described by
+Chapter 8 "Protocol Layer" of the <a class=away
+href="https://www.usb.org/document-library/usb-20-specification">the
+Universal Serial Bus Specification Revision 2.0</a>.
 </td>
 </tr>
               </table>


### PR DESCRIPTION
USB 2.0/1.1/1.0 devices (or 3.x and newer when connected to hosts that
are not Super-Speed capable) operate at one of three speeds:
  * Low-Speed (1.5 Mbps)
  * Full-Speed (12 Mbps)
  * High-Speed (480 Mbps)

While the packets are generally common to all three speeds, there are
some differences that span across different layers. The capture speed
should be available to analyzer and it makes sense to expose it via
speed specific linktypes. Existing USB 2.0/1.1/1.0 captures can be
manually, retroactively updated to speed specific linktype.

Low-Speed device will always operate at Low-Speed, regardless of what
host it is connected to. USB cable connected to Low-Speed device only
ever carries packets sent at Low-Speed.

High-Speed device will operate at High-Speed when connected to High-Speed
capable host. If High-Speed Detection Handshake succeeds, the cable will
only carry High-Speed packets.

Full-Speed device will always operate at Full-Speed, regardless of what
host it is connected to. High-Speed device connected to Full-Speed host
or hub, will operate at Full-Speed. The cable connected to device
operating at Full-Speed can only carry Full-Speed or Low-Speed packets
preceded by Low-Speed preamble (PRE packet) sent at Full-Speed. Non-hub
device operating at Full-Speed always ignores Low-Speed packets. The hub
forwards the Low-Speed packets to downstream ports but does not act upon
the actual Low-Speed packet contents. The packets intended for device
operating at Full-Speed are always sent at Full-Speed.