### PR TITLE
Link to internal page for LINKTYPE_BLUETOOTH_BREDR_BB

### DIFF
--- a/htmlsrc/linktypes.html
+++ b/htmlsrc/linktypes.html
@@ -1247,7 +1247,7 @@ Linux Monitor encapsulation of traffic for the BlueZ stack</a>.
 <td class="number">255</td>
 <td class="symbol">DLT_BLUETOOTH_BREDR_BB</td>
 <td>
-<a class=away href="http://www.whiterocker.com/bt/LINKTYPE_BLUETOOTH_BREDR_BB.html">Bluetooth
+<a href="linktypes/LINKTYPE_BLUETOOTH_BREDR_BB.html">Bluetooth
 Basic Rate and Enhanced Data Rate baseband packets</a>.
 </td>
 </tr>

--- a/linktypes.html
+++ b/linktypes.html
@@ -1297,7 +1297,7 @@ Linux Monitor encapsulation of traffic for the BlueZ stack</a>.
 <td class="number">255</td>
 <td class="symbol">DLT_BLUETOOTH_BREDR_BB</td>
 <td>
-<a class=away href="http://www.whiterocker.com/bt/LINKTYPE_BLUETOOTH_BREDR_BB.html">Bluetooth
+<a href="linktypes/LINKTYPE_BLUETOOTH_BREDR_BB.html">Bluetooth
 Basic Rate and Enhanced Data Rate baseband packets</a>.
 </td>
 </tr>


### PR DESCRIPTION
An internal page was available for LINKTYPE_BLUETOOTH_BREDR_BB at https://www.tcpdump.org/linktypes/LINKTYPE_BLUETOOTH_BREDR_BB.html, but the linktypes.html file linked to the external/original one at http://www.whiterocker.com/bt/LINKTYPE_BLUETOOTH_BREDR_BB.html