### PR TITLE
Update pcap.html

### DIFF
--- a/htmlsrc/pcap.html
+++ b/htmlsrc/pcap.html
@@ -516,7 +516,7 @@ struct sniff_tcp {
 	tcp_seq th_seq;		/* sequence number */
 	tcp_seq th_ack;		/* acknowledgement number */
 	u_char th_offx2;	/* data offset, rsvd */
-#define TH_OFF(th)	(((th)-&gt;th_offx2 &amp; 0xf0) &gt; 4)
+#define TH_OFF(th)	(((th)-&gt;th_offx2 &amp; 0xf0) &gt;&gt; 4)
 	u_char th_flags;
 #define TH_FIN 0x01
 #define TH_SYN 0x02

--- a/pcap.html
+++ b/pcap.html
@@ -560,7 +560,7 @@ struct sniff_tcp {
 	tcp_seq th_seq;		/* sequence number */
 	tcp_seq th_ack;		/* acknowledgement number */
 	u_char th_offx2;	/* data offset, rsvd */
-#define TH_OFF(th)	(((th)-&gt;th_offx2 &amp; 0xf0) &gt; 4)
+#define TH_OFF(th)	(((th)-&gt;th_offx2 &amp; 0xf0) &gt;&gt; 4)
 	u_char th_flags;
 #define TH_FIN 0x01
 #define TH_SYN 0x02


### PR DESCRIPTION
Missing ">" symbol when defining TH_OFF. It should be the right shift operator instead of just a greater than sign.