### PR TITLE
linktypes: add DLT for MDB

### DIFF
--- a/htmlsrc/linktypes.html
+++ b/htmlsrc/linktypes.html
@@ -2360,6 +2360,18 @@ Silicon Labs debug channel protocol, as described in
 Ultra-wideband (UWB) controller interface protocol (UCI).</a>
 </td>
 </tr>
+
+<tr>
+<td class="symbol">LINKTYPE_MDB</td>
+<td class="number">300</td>
+<td class="symbol">DLT_MDB</td>
+<td>
+MDB (Multi-Drop Bus) protocol between a vending machine controller and
+peripherals inside the vending machine, with the message format specified by
+<a class=away href="https://www.kaiser.cx/pcap-mdb.html">the PCAP format for
+MDB specification</a>.
+</td>
+</tr>
               </table>
             </div>
           </div>

--- a/linktypes.html
+++ b/linktypes.html
@@ -2404,6 +2404,18 @@ Silicon Labs debug channel protocol, as described in
 Ultra-wideband (UWB) controller interface protocol (UCI).</a>
 </td>
 </tr>
+
+<tr>
+<td class="symbol">LINKTYPE_MDB</td>
+<td class="number">300</td>
+<td class="symbol">DLT_MDB</td>
+<td>
+MDB (Multi-Drop Bus) protocol between a vending machine controller and
+peripherals inside the vending machine, with the message format specified by
+<a class=away href="https://www.kaiser.cx/pcap-mdb.html">the PCAP format for
+MDB specification</a>.
+</td>
+</tr>
               </table>
             </div>
           </div>


### PR DESCRIPTION
Add a link-layer header type for the MDB (Multi-Drop Bus) protocol.