### PR TITLE
linktypes: add DLT for DECT_NR

### DIFF
--- a/htmlsrc/linktypes.html
+++ b/htmlsrc/linktypes.html
@@ -2372,6 +2372,19 @@ peripherals inside the vending machine, with the message format specified by
 MDB specification</a>.
 </td>
 </tr>
+
+<tr>
+<td class="symbol">LINKTYPE_DECT_NR</td>
+<td class="number">301</td>
+<td class="symbol">DLT_DECT_NR</td>
+<td>
+DECT-2020 New Radio (NR) MAC layer specified in
+<a class=away href="https://www.etsi.org/committee/1394-dect">ETSI TS 103 636-4</a>.
+The Physical Header Field is always encoded using 80 bits (10 bytes). Broadcast transmissions
+using 40 bits (5 bytes) is padded with 40 zero bits (5 bytes). When padding is used the Receiver
+Identity value 0x0000 (reserved address) is used to detect broadcast transmissions.
+</td>
+</tr>
               </table>
             </div>
           </div>

--- a/linktypes.html
+++ b/linktypes.html
@@ -2416,6 +2416,19 @@ peripherals inside the vending machine, with the message format specified by
 MDB specification</a>.
 </td>
 </tr>
+
+<tr>
+<td class="symbol">LINKTYPE_DECT_NR</td>
+<td class="number">301</td>
+<td class="symbol">DLT_DECT_NR</td>
+<td>
+DECT-2020 New Radio (NR) MAC layer specified in
+<a class=away href="https://www.etsi.org/committee/1394-dect">ETSI TS 103 636-4</a>.
+The Physical Header Field is always encoded using 80 bits (10 bytes). Broadcast transmissions
+using 40 bits (5 bytes) is padded with 40 zero bits (5 bytes). When padding is used the Receiver
+Identity value 0x0000 (reserved address) is used to detect broadcast transmissions.
+</td>
+</tr>
               </table>
             </div>
           </div>


### PR DESCRIPTION
Add a link-layer header type for the DECT New Radio protocol defined in ETSI TS 103 636-4.