### PR TITLE
Add Bit-Twist to related projects

### DIFF
--- a/htmlsrc/related.html
+++ b/htmlsrc/related.html
@@ -858,6 +858,24 @@
                     <div class="entry">
                         <dl>
                             <dt>
+                                <a class=away href="https://bittwist.sourceforge.io/">Bit-Twist</a>
+                            </dt>
+                            <dd>
+                                Bit-Twist is a powerful libpcap-based Ethernet packet generator
+                                and editor, written in POSIX-compliant C, designed to complement
+                                tcpdump by replaying captured traffic from pcap files onto live
+                                networks. It supports Windows (using Npcap), Linux, BSD, and macOS,
+                                allowing the editing of key fields in Ethernet, ARP, IPv4, IPv6,
+                                ICMP, and TCP/UDP headers. It can also generate pcap files from
+                                its built-in templates, enabling packet creation without existing
+                                capture files, along with payload generation from uniformly
+                                distributed random bytes or fixed bytes, such as hex streams from
+                                Wireshark. Ideal for testing firewalls, IDS, IPS, routers,
+                                switches, load balancers, and other network equipment, it delivers
+                                performance that matches the line rate of your NIC, up to 10Gbps.
+                            </dd>
+
+                            <dt>
                                 <a class=away href="https://tcpreplay.appneta.com/">tcpreplay</a>
                             </dt>
                             <dd>

--- a/related.html
+++ b/related.html
@@ -902,6 +902,24 @@
                     <div class="entry">
                         <dl>
                             <dt>
+                                <a class=away href="https://bittwist.sourceforge.io/">Bit-Twist</a>
+                            </dt>
+                            <dd>
+                                Bit-Twist is a powerful libpcap-based Ethernet packet generator
+                                and editor, written in POSIX-compliant C, designed to complement
+                                tcpdump by replaying captured traffic from pcap files onto live
+                                networks. It supports Windows (using Npcap), Linux, BSD, and macOS,
+                                allowing the editing of key fields in Ethernet, ARP, IPv4, IPv6,
+                                ICMP, and TCP/UDP headers. It can also generate pcap files from
+                                its built-in templates, enabling packet creation without existing
+                                capture files, along with payload generation from uniformly
+                                distributed random bytes or fixed bytes, such as hex streams from
+                                Wireshark. Ideal for testing firewalls, IDS, IPS, routers,
+                                switches, load balancers, and other network equipment, it delivers
+                                performance that matches the line rate of your NIC, up to 10Gbps.
+                            </dd>
+
+                            <dt>
                                 <a class=away href="https://tcpreplay.appneta.com/">tcpreplay</a>
                             </dt>
                             <dd>


### PR DESCRIPTION
Bit-Twist is a libpcap-based Ethernet packet generator and editor that complements tcpdump by replaying captured pcap files onto live networks on Windows (using Npcap), Linux, BSD, and macOS, allowing header editing and payload generation for testing firewalls and IDS/IPS with performance up to 10Gbps.