### PR TITLE
Add DLT and linktype for OASIS.

### DIFF
--- a/htmlsrc/linktypes.html
+++ b/htmlsrc/linktypes.html
@@ -2128,6 +2128,16 @@ messages, with a pseudo-header</a>.
 layer</a>.
 </td>
 </tr>
+
+<tr>
+<td class="symbol">LINKTYPE_OASIS</td>
+<td class="number">302</td>
+<td class="symbol">DLT_OASIS</td>
+<td>
+<a href="https://cpm80.com/oasis-send-recv-protocol.html">OASIS Send/Receive Protocol
+layer</a>.
+</td>
+</tr>
               </table>
             </div>
           </div>

--- a/linktypes.html
+++ b/linktypes.html
@@ -2172,6 +2172,16 @@ messages, with a pseudo-header</a>.
 layer</a>.
 </td>
 </tr>
+
+<tr>
+<td class="symbol">LINKTYPE_OASIS</td>
+<td class="number">302</td>
+<td class="symbol">DLT_OASIS</td>
+<td>
+<a href="https://cpm80.com/oasis-send-recv-protocol.html">OASIS Send/Receive Protocol
+layer</a>.
+</td>
+</tr>
               </table>
             </div>
           </div>


### PR DESCRIPTION
Add a link-layer header type for the OASIS Send/Receive protocol:

Protocol documentation:
https://cpm80.com/oasis-send-recv-protocol.html

Original Protocol reference document:
http://www.bitsavers.org/pdf/phaseOneSystems/oasis/Communications_Reference_Manual_2ed.pdf

Corresponding PR for libpcap:
https://github.com/the-tcpdump-group/libpcap/pull/1524

Link to GitHub project with more details:
https://github.com/hharte/oasis-utils/blob/main/wireshark/OASIS-send-recv-protocol.md

Thank you for your consideration.
-Howard
