### PR TITLE
LINKTYPE_LINUX_SLL2: Remove duplicated paragraphs

### DIFF
--- a/htmlsrc/linktypes/LINKTYPE_LINUX_SLL2.html
+++ b/htmlsrc/linktypes/LINKTYPE_LINUX_SLL2.html
@@ -60,17 +60,6 @@ else;</li>
 <li>4, if the packet was sent by us.</li>
 </ul>
 <p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778), the protocol type field
-contains a <a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
-protocol type.
-</p>
-<p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IEEE80211_RADIOTAP</code> (803), the protocol
-type field is ignored, and the payload following the <code>LINKTYPE_LINUX_SLL</code>
-header begins with <a class=away href="http://www.radiotap.org/">Radiotap
-link-layer information</a> followed by an 802.11 header.
-</p>
-<p>
 The link-layer address length field is in big-endian byte order; it
 contains the length of the link-layer address of the sender of the
 packet.  That length could be zero.

--- a/linktypes/LINKTYPE_LINUX_SLL2.html
+++ b/linktypes/LINKTYPE_LINUX_SLL2.html
@@ -104,17 +104,6 @@ else;</li>
 <li>4, if the packet was sent by us.</li>
 </ul>
 <p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778), the protocol type field
-contains a <a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
-protocol type.
-</p>
-<p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IEEE80211_RADIOTAP</code> (803), the protocol
-type field is ignored, and the payload following the <code>LINKTYPE_LINUX_SLL</code>
-header begins with <a class=away href="http://www.radiotap.org/">Radiotap
-link-layer information</a> followed by an 802.11 header.
-</p>
-<p>
 The link-layer address length field is in big-endian byte order; it
 contains the length of the link-layer address of the sender of the
 packet.  That length could be zero.


### PR DESCRIPTION
The paragraphs describing the effects of ARPHRD_IPGRE and ARPHRD_IEEE80211_RADIOTAP on the protocol type field and payload are duplicated. They appear once after the description of the link-layer address and before the payload, in the middle of the description of the effects of several other ARPHRD_ types, and once after the description of the packet type field and before the link-layer address length field (neither of which are related.)

There is a case, perhaps, for listing them either after the protocol type field or ARPHRD_ type instead. LINKTYPE_LINUX_SLL makes this somewhat easier because the protocol type field and payload are adjacent fields, so the descriptions can occur at the end of one field and the beginning of the next.