### PR TITLE
LINKTYPE_LINUX_{SLL,SLL2}: ARPHRD_IP6GRE uses GRE protocol types as well

### DIFF
--- a/htmlsrc/linktypes/LINKTYPE_LINUX_SLL.html
+++ b/htmlsrc/linktypes/LINKTYPE_LINUX_SLL.html
@@ -69,8 +69,9 @@ is <a href="../linktypes/LINKTYPE_NETLINK.html">a
 being the Netlink protocol type.
 </p>
 <p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778), the protocol type field
-contains a <a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
+If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778) or
+<code>ARPHRD_IP6GRE</code> (823), the protocol type field contains a
+<a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
 protocol type for the payload.
 </p>
 <p>

--- a/htmlsrc/linktypes/LINKTYPE_LINUX_SLL2.html
+++ b/htmlsrc/linktypes/LINKTYPE_LINUX_SLL2.html
@@ -80,8 +80,9 @@ is <a href="../linktypes/LINKTYPE_NETLINK.html">a
 being the Netlink protocol type.
 </p>
 <p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778), the protocol type field
-contains a <a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
+If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778) or
+<code>ARPHRD_IP6GRE</code> (823), the protocol type field contains a
+<a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
 protocol type for the payload.
 </p>
 <p>

--- a/linktypes/LINKTYPE_LINUX_SLL.html
+++ b/linktypes/LINKTYPE_LINUX_SLL.html
@@ -113,8 +113,9 @@ is <a href="../linktypes/LINKTYPE_NETLINK.html">a
 being the Netlink protocol type.
 </p>
 <p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778), the protocol type field
-contains a <a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
+If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778) or
+<code>ARPHRD_IP6GRE</code> (823), the protocol type field contains a
+<a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
 protocol type for the payload.
 </p>
 <p>

--- a/linktypes/LINKTYPE_LINUX_SLL2.html
+++ b/linktypes/LINKTYPE_LINUX_SLL2.html
@@ -124,8 +124,9 @@ is <a href="../linktypes/LINKTYPE_NETLINK.html">a
 being the Netlink protocol type.
 </p>
 <p>
-If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778), the protocol type field
-contains a <a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
+If the <code>ARPHRD_</code> type is <code>ARPHRD_IPGRE</code> (778) or
+<code>ARPHRD_IP6GRE</code> (823), the protocol type field contains a
+<a class=away href="https://datatracker.ietf.org/doc/html/rfc2784">GRE</a>
 protocol type for the payload.
 </p>
 <p>


### PR DESCRIPTION
As with ARPHRD_IPGRE (778), ARPHRD_IP6GRE (823) also uses GRE protocol types, which matters in the small list of customary GRE protocols, or for protocol types used over GRE but not actually registered Ethertypes (or in some cases possibly the Ethertype number being registered by a company privately, and then used for different purposes on LANs directly version over GRE.)