### PR TITLE
Add LINKTYPE_ETW2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/htmlsrc/linktypes.html
+++ b/htmlsrc/linktypes.html
@@ -2059,7 +2059,7 @@ frames.</a>
 <td class="number">290</td>
 <td class="symbol">DLT_ETW</td>
 <td>
-<a href="linktypes/LINKTYPE_ETW.html">Event Tracing for Windows messages</a>.
+<a href="linktypes/LINKTYPE_ETW.html">Event Tracing for Windows messages v1</a>. This was used by <code>Wireshark &le; 4.6.X</code> to talk with its <code>etwdump</code> extcap.
 </td>
 </tr>
 
@@ -2201,6 +2201,15 @@ Unstructured data for manual debugging only.
 DECT-2020 New Radio (NR) TAP with a <a class=away
 href="https://github.com/DSRCorporation/dect-nr-tap">custom metadata header</a>
 prepended to a standard <code>DLT_DECT_NR</code> MAC-layer frame.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_ETW2</td>
+<td class="number">305</td>
+<td class="symbol">DLT_ETW2</td>
+<td>
+<a href="linktypes/LINKTYPE_ETW2.html">Event Tracing for Windows messages v2</a>. This is used since <code>Wireshark &gt; 4.7</code> to talk with its <code>etwdump</code> extcap.
 </td>
 </tr>
               </table>

--- a/htmlsrc/linktypes/LINKTYPE_ETW.html
+++ b/htmlsrc/linktypes/LINKTYPE_ETW.html
@@ -4,6 +4,10 @@
                 LINKTYPE_ETW
             </h2>
             <div class="entry">
+                <p>
+                NOTE: This LINKTYPE refers to structures that should be considered a Wireshark internal and is not standardized outside of this document.
+                </p>
+
                 <h3 class="subtitle">Packet structure</h3>
 <pre>
  0                   1                   2                   3
@@ -15,20 +19,29 @@
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ 80 octets
 |                      ETW_BUFFER_CONTEXT                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                        UserDataLength                         |
+|      ExtendedDataCount        |           TlvCount            |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      MessageLength                            |
+|                       PropertiesCount                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      ProviderNameLength                       |
+/                   Extended Data Headers                       /
+/      EVENT_HEADER_EXTENDED_DATA_ITEM[ExtendedDataCount]       /
+/                                                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/                          UserData                             /
-/              variable length, padded to 32 bits               /
+/                         TLV Headers                           /
+/                       ETW_TLV[TlvCount]                       /
+/                                                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/                          Message                              /
-/              variable length, padded to 32 bits               /
+/                       Property Headers                        /
+/                   ETW_PROPERTY[PropertiesCount]               /
+/                                                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/                          ProviderName                         /
-/              variable length, padded to 32 bits               /
+/                             DATA                              /
+/                              ..                               /
+/                              ..                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 
@@ -76,22 +89,56 @@ href="https://learn.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-e
 page for the ETW_BUFFER_CONTEXT structure</a>.
 </p>
 <p>
-UserDataLength is the length of UserData; it doesn't include the padding octets of UserData.
+ExtendedDataCount is the amount of <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item">EVENT_HEADER_EXTENDED_DATA_ITEM</a> items.
+The Extended Data Headers are identical to the one described in Microsoft's documentation, which the exception of the DataPtr. This field points towards an offset relative to the beginning of the EVENT_HEADER instead of an actual pointer.
 <p>
-MessageLength is the length of Message; it doesn't include the padding octets of Message.
+TlvCount is the amount of ETW_TLV items.
 </p>
 <p>
-ProviderNameLength is the length of ProviderName; it doesn't include the padding octets of ProviderName.
+PropertiesCount is the amount of ETW_PROPERTY items.
 </p>
+<h4 class="subtitle">ETW_TLV structure</h4>
 <p>
-UserData is specific event data of the provider; its format is defined by the provider.
+ETL_TLV defines arbitrary data that is included by the sniffer in the capture process. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                              Type                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Offset                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Length                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+<ul>
+<li>Type: one of the following</li>
+<pre>
+enum ETL_TLV_TYPE {
+    TLV_USER_DATA     = 0,  // Specific event data of the provider; its format is defined by the provider.
+    TLV_MESSAGE       = 1,  // A null-terminated UTF-16LE string that contains the event message string.
+    TLV_PROVIDER_NAME = 2,  // A null-terminated UTF-16LE string that contains the event provider name string.
+};
+</pre>
+<li>Offset: refers to an offset relative to the beginning of the EVENT_HEADER.</li>
+<li>Length: is the size of the data referred by this TLV.</li>
+</ul>
+For more information about the "EventMessage" or "ProviderName" strings, refer to <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/ns-tdh-trace_event_info">TRACE_EVENT_INFO</a>.
 </p>
+<h4 class="subtitle">ETW_PROPERTY structure</h4>
 <p>
-Message is a null-terminated UTF-16LE string that contains the event message string.
+ETW_PROPERTY defines a property by its name (key) and value. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             OFFSET                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|           KEYLENGTH           |          VALUELENGTH          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+It points towards the concatenation of the Key and Value, both as null-terminated UTF-16LE strings without padding in between, as outputed by <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/nf-tdh-tdhformatproperty">TdhFormatProperty()</a>. The Offset is from the beginning of the EVENT_HEADER.
 </p>
-<p>
-Providername is a null-terminated UTF-16LE string that contains the event provider name string.
-</p>
-            </div>
+</div>
           </div>
           <!-- End of LINKTYPE_ETW section -->

--- a/htmlsrc/linktypes/LINKTYPE_ETW.html
+++ b/htmlsrc/linktypes/LINKTYPE_ETW.html
@@ -4,6 +4,10 @@
                 LINKTYPE_ETW
             </h2>
             <div class="entry">
+                <p>
+                    NOTE: This LINKTYPE describes a format that has been superseeded by <a href="LINKTYPE_ETW2.html"><code>LINKTYPE_ETW2</code></a>.
+                </p>
+
                 <h3 class="subtitle">Packet structure</h3>
 <pre>
  0                   1                   2                   3

--- a/htmlsrc/linktypes/LINKTYPE_ETW2.html
+++ b/htmlsrc/linktypes/LINKTYPE_ETW2.html
@@ -1,0 +1,144 @@
+          <!-- Start of LINKTYPE_ETW section -->
+          <div class="post">
+            <h2 class="title">
+                LINKTYPE_ETW2
+            </h2>
+            <div class="entry">
+                <p>
+                    NOTE: This LINKTYPE describes structures that are used internally by Wireshark to transfer data between <code>etwdump</code> and its dissector. This superseeds <a href="LINKTYPE_ETW.html">LINKTYPE_ETW</a>.
+                </p>
+
+                <h3 class="subtitle">Packet structure</h3>
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                                                               /
+/                        EVENT_HEADER                           /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ 80 octets
+|                      ETW_BUFFER_CONTEXT                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|      ExtendedDataCount        |           TlvCount            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       PropertiesCount                         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                   Extended Data Headers                       /
+/      EVENT_HEADER_EXTENDED_DATA_ITEM[ExtendedDataCount]       /
+/                                                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                         TLV Headers                           /
+/                       ETW_TLV[TlvCount]                       /
+/                                                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                       Property Headers                        /
+/                   ETW_PROPERTY[PropertiesCount]               /
+/                                                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                             DATA                              /
+/                              ..                               /
+/                              ..                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+
+                <h3 class="subtitle">Description</h3>
+<p>
+
+All multi-octet numerical fields are little-endian.  All primitive types
+in this document are from Windows and their size can be found in <a class=away
+href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/efda8314-6e41-4837-8299-38ba0ee04b92">section
+2.2 "Common Data Types"</a> of
+<a class=away
+href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cca27429-5689-4a16-b2b4-9325d93e4ba2">[MS-DTYP]:
+Windows Data Types</a>.
+
+</p>
+<p>
+<code>EVENT_HEADER</code> is 80 octets long; its structure is described on <a class=away
+href="https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header">Microsoft's
+page for the <code>EVENT_HEADER</code> structure</a>.
+</p>
+<p>
+The bit values of Flags in <code>EVENT_HEADER</code> are:
+</p>
+<pre>
+#define EVENT_HEADER_FLAG_EXTENDED_INFO         0x0001
+#define EVENT_HEADER_FLAG_PRIVATE_SESSION       0x0002
+#define EVENT_HEADER_FLAG_STRING_ONLY           0x0004
+#define EVENT_HEADER_FLAG_TRACE_MESSAGE         0x0008
+#define EVENT_HEADER_FLAG_NO_CPUTIME            0x0010
+#define EVENT_HEADER_FLAG_32_BIT_HEADER         0x0020
+#define EVENT_HEADER_FLAG_64_BIT_HEADER         0x0040
+#define EVENT_HEADER_FLAG_CLASSIC_HEADER        0x0100
+</pre>
+<p>
+The bit values of <code>EventProperty</code> in <code>EVENT_HEADER</code> are:
+</p>
+<pre>
+#define EVENT_HEADER_PROPERTY_XML               0x0001
+#define EVENT_HEADER_PROPERTY_FORWARDED_XML     0x0002
+#define EVENT_HEADER_PROPERTY_LEGACY_EVENTLOG   0x0004
+</pre>
+<p>
+<code>ETW_BUFFER_CONTEXT</code> is 4 octets long; its structure is described on <a class=away
+href="https://learn.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-etw_buffer_context">Microsoft's
+page for the <code>ETW_BUFFER_CONTEXT</code> structure</a>.
+</p>
+<p>
+<code>ExtendedDataCount</code> is the amount of <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item"><code>EVENT_HEADER_EXTENDED_DATA_ITEM</code></a> items.
+The Extended Data Headers are identical to the one described in Microsoft's documentation, which the exception of the <code>DataPtr</code>. This field points towards an offset relative to the beginning of the <code>EVENT_HEADER</code> instead of an actual pointer.
+<p>
+<code>TlvCount</code> is the amount of <code>ETW_TLV</code> items.
+</p>
+<p>
+<code>PropertiesCount</code> is the amount of <code>ETW_PROPERTY</code> items.
+</p>
+<h4 class="subtitle"><code>ETW_TLV</code> structure</h4>
+<p>
+<code>ETL_TLV</code> defines arbitrary data that is included by the sniffer in the capture process. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                              Type                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Offset                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Length                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+<ul>
+<li>Type: one of the following</li>
+<pre>
+enum ETL_TLV_TYPE {
+    TLV_USER_DATA     = 0,  // Specific event data of the provider; its format is defined by the provider.
+    TLV_MESSAGE       = 1,  // A null-terminated UTF-16LE string that contains the event message string.
+    TLV_PROVIDER_NAME = 2,  // A null-terminated UTF-16LE string that contains the event provider name string.
+};
+</pre>
+<li><code>Offset</code>: refers to an offset relative to the beginning of the EVENT_HEADER.</li>
+<li><code>Length</code>: is the size of the data referred by this TLV.</li>
+</ul>
+For more information about the <code>EventMessage</code> or <code>ProviderName</code> strings, refer to <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/ns-tdh-trace_event_info">TRACE_EVENT_INFO</a>.
+</p>
+<h4 class="subtitle"><code>ETW_PROPERTY</code> structure</h4>
+<p>
+<code>ETW_PROPERTY</code> defines a property by its name (key) and value. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             OFFSET                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|           KEYLENGTH           |          VALUELENGTH          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+It points towards the concatenation of the Key and Value, both as null-terminated UTF-16LE strings without padding in between, as outputed by <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/nf-tdh-tdhformatproperty">TdhFormatProperty()</a>. The Offset is from the beginning of the <code>EVENT_HEADER</code>.
+</p>
+</div>
+          </div>
+          <!-- End of LINKTYPE_ETW section -->

--- a/linktypes.html
+++ b/linktypes.html
@@ -2103,7 +2103,7 @@ frames.</a>
 <td class="number">290</td>
 <td class="symbol">DLT_ETW</td>
 <td>
-<a href="linktypes/LINKTYPE_ETW.html">Event Tracing for Windows messages</a>.
+<a href="linktypes/LINKTYPE_ETW.html">Event Tracing for Windows messages v1</a>. This was used by <code>Wireshark &le; 4.6.X</code> to talk with its <code>etwdump</code> extcap.
 </td>
 </tr>
 
@@ -2245,6 +2245,15 @@ Unstructured data for manual debugging only.
 DECT-2020 New Radio (NR) TAP with a <a class=away
 href="https://github.com/DSRCorporation/dect-nr-tap">custom metadata header</a>
 prepended to a standard <code>DLT_DECT_NR</code> MAC-layer frame.
+</td>
+</tr>
+
+<tr>
+<td class="symbol">LINKTYPE_ETW2</td>
+<td class="number">305</td>
+<td class="symbol">DLT_ETW2</td>
+<td>
+<a href="linktypes/LINKTYPE_ETW2.html">Event Tracing for Windows messages v2</a>. This is used since <code>Wireshark &gt; 4.7</code> to talk with its <code>etwdump</code> extcap.
 </td>
 </tr>
               </table>

--- a/linktypes/LINKTYPE_ETW.html
+++ b/linktypes/LINKTYPE_ETW.html
@@ -48,6 +48,10 @@
                 LINKTYPE_ETW
             </h2>
             <div class="entry">
+                <p>
+                NOTE: This LINKTYPE refers to structures that should be considered a Wireshark internal and is not standardized outside of this document.
+                </p>
+
                 <h3 class="subtitle">Packet structure</h3>
 <pre>
  0                   1                   2                   3
@@ -59,20 +63,29 @@
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ 80 octets
 |                      ETW_BUFFER_CONTEXT                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                        UserDataLength                         |
+|      ExtendedDataCount        |           TlvCount            |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      MessageLength                            |
+|                       PropertiesCount                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      ProviderNameLength                       |
+/                   Extended Data Headers                       /
+/      EVENT_HEADER_EXTENDED_DATA_ITEM[ExtendedDataCount]       /
+/                                                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/                          UserData                             /
-/              variable length, padded to 32 bits               /
+/                         TLV Headers                           /
+/                       ETW_TLV[TlvCount]                       /
+/                                                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/                          Message                              /
-/              variable length, padded to 32 bits               /
+/                       Property Headers                        /
+/                   ETW_PROPERTY[PropertiesCount]               /
+/                                                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/                          ProviderName                         /
-/              variable length, padded to 32 bits               /
+/                             DATA                              /
+/                              ..                               /
+/                              ..                               /
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 
@@ -120,23 +133,57 @@ href="https://learn.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-e
 page for the ETW_BUFFER_CONTEXT structure</a>.
 </p>
 <p>
-UserDataLength is the length of UserData; it doesn't include the padding octets of UserData.
+ExtendedDataCount is the amount of <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item">EVENT_HEADER_EXTENDED_DATA_ITEM</a> items.
+The Extended Data Headers are identical to the one described in Microsoft's documentation, which the exception of the DataPtr. This field points towards an offset relative to the beginning of the EVENT_HEADER instead of an actual pointer.
 <p>
-MessageLength is the length of Message; it doesn't include the padding octets of Message.
+TlvCount is the amount of ETW_TLV items.
 </p>
 <p>
-ProviderNameLength is the length of ProviderName; it doesn't include the padding octets of ProviderName.
+PropertiesCount is the amount of ETW_PROPERTY items.
 </p>
+<h4 class="subtitle">ETW_TLV structure</h4>
 <p>
-UserData is specific event data of the provider; its format is defined by the provider.
+ETL_TLV defines arbitrary data that is included by the sniffer in the capture process. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                              Type                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Offset                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Length                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+<ul>
+<li>Type: one of the following</li>
+<pre>
+enum ETL_TLV_TYPE {
+    TLV_USER_DATA     = 0,  // Specific event data of the provider; its format is defined by the provider.
+    TLV_MESSAGE       = 1,  // A null-terminated UTF-16LE string that contains the event message string.
+    TLV_PROVIDER_NAME = 2,  // A null-terminated UTF-16LE string that contains the event provider name string.
+};
+</pre>
+<li>Offset: refers to an offset relative to the beginning of the EVENT_HEADER.</li>
+<li>Length: is the size of the data referred by this TLV.</li>
+</ul>
+For more information about the "EventMessage" or "ProviderName" strings, refer to <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/ns-tdh-trace_event_info">TRACE_EVENT_INFO</a>.
 </p>
+<h4 class="subtitle">ETW_PROPERTY structure</h4>
 <p>
-Message is a null-terminated UTF-16LE string that contains the event message string.
+ETW_PROPERTY defines a property by its name (key) and value. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             OFFSET                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|           KEYLENGTH           |          VALUELENGTH          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+It points towards the concatenation of the Key and Value, both as null-terminated UTF-16LE strings without padding in between, as outputed by <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/nf-tdh-tdhformatproperty">TdhFormatProperty()</a>. The Offset is from the beginning of the EVENT_HEADER.
 </p>
-<p>
-Providername is a null-terminated UTF-16LE string that contains the event provider name string.
-</p>
-            </div>
+</div>
           </div>
           <!-- End of LINKTYPE_ETW section -->
         </div>

--- a/linktypes/LINKTYPE_ETW.html
+++ b/linktypes/LINKTYPE_ETW.html
@@ -48,6 +48,10 @@
                 LINKTYPE_ETW
             </h2>
             <div class="entry">
+                <p>
+                    NOTE: This LINKTYPE describes a format that has been superseeded by <a href="LINKTYPE_ETW2.html"><code>LINKTYPE_ETW2</code></a>.
+                </p>
+
                 <h3 class="subtitle">Packet structure</h3>
 <pre>
  0                   1                   2                   3

--- a/linktypes/LINKTYPE_ETW2.html
+++ b/linktypes/LINKTYPE_ETW2.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <!-- HEAD -->
+    <head>
+        <meta charset="utf-8">
+        <title>LINKTYPE_ETW2 | TCPDUMP &amp; LIBPCAP</title>
+        <meta name="description" content="Web site of Tcpdump and Libpcap">
+        <link href="../style.css" rel="stylesheet" type="text/css" media="screen">
+        <link href="../images/T-32x32.png" rel="shortcut icon" type="image/png">
+    </head>
+    <!-- END OF HTML HEAD -->
+
+    <!-- BODY -->
+    <body>
+
+        <!-- TOP MENU -->
+        <div id="menu">
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../security.html">Security</a></li>
+                <li><a href="../faq.html">FAQ</a></li>
+                <li><a href="../manpages/">Man Pages</a></li>
+                <li><a href="../ci.html">CI</a></li>
+                <li><a href="../linktypes.html">Link-Layer Header Types</a></li>
+                <li><a href="../related.html">See Also</a></li>
+                <li><a href="../old_releases.html">Old Releases</a></li>
+                <li><a href="../thanks.html">Thanks!</a></li>
+            </ul>
+        </div>
+        <!-- END OF TOP MENU -->
+
+        <!-- PAGE HEADER -->
+        <div id="splash">
+            <br><img src="../images/logo.png" alt="">
+        </div>
+        <div id="logo">
+            <hr>
+        </div>
+        <!-- END OF PAGE HEADER -->
+
+        <!-- PAGE CONTENTS -->
+        <div id="page">
+
+          <!-- Start of LINKTYPE_ETW section -->
+          <div class="post">
+            <h2 class="title">
+                LINKTYPE_ETW2
+            </h2>
+            <div class="entry">
+                <p>
+                    NOTE: This LINKTYPE describes structures that are used internally by Wireshark to transfer data between <code>etwdump</code> and its dissector. This superseeds <a href="LINKTYPE_ETW.html">LINKTYPE_ETW</a>.
+                </p>
+
+                <h3 class="subtitle">Packet structure</h3>
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                                                               /
+/                        EVENT_HEADER                           /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ 80 octets
+|                      ETW_BUFFER_CONTEXT                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|      ExtendedDataCount        |           TlvCount            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       PropertiesCount                         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                   Extended Data Headers                       /
+/      EVENT_HEADER_EXTENDED_DATA_ITEM[ExtendedDataCount]       /
+/                                                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                         TLV Headers                           /
+/                       ETW_TLV[TlvCount]                       /
+/                                                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                       Property Headers                        /
+/                   ETW_PROPERTY[PropertiesCount]               /
+/                                                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                             DATA                              /
+/                              ..                               /
+/                              ..                               /
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+
+                <h3 class="subtitle">Description</h3>
+<p>
+
+All multi-octet numerical fields are little-endian.  All primitive types
+in this document are from Windows and their size can be found in <a class=away
+href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/efda8314-6e41-4837-8299-38ba0ee04b92">section
+2.2 "Common Data Types"</a> of
+<a class=away
+href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cca27429-5689-4a16-b2b4-9325d93e4ba2">[MS-DTYP]:
+Windows Data Types</a>.
+
+</p>
+<p>
+<code>EVENT_HEADER</code> is 80 octets long; its structure is described on <a class=away
+href="https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header">Microsoft's
+page for the <code>EVENT_HEADER</code> structure</a>.
+</p>
+<p>
+The bit values of Flags in <code>EVENT_HEADER</code> are:
+</p>
+<pre>
+#define EVENT_HEADER_FLAG_EXTENDED_INFO         0x0001
+#define EVENT_HEADER_FLAG_PRIVATE_SESSION       0x0002
+#define EVENT_HEADER_FLAG_STRING_ONLY           0x0004
+#define EVENT_HEADER_FLAG_TRACE_MESSAGE         0x0008
+#define EVENT_HEADER_FLAG_NO_CPUTIME            0x0010
+#define EVENT_HEADER_FLAG_32_BIT_HEADER         0x0020
+#define EVENT_HEADER_FLAG_64_BIT_HEADER         0x0040
+#define EVENT_HEADER_FLAG_CLASSIC_HEADER        0x0100
+</pre>
+<p>
+The bit values of <code>EventProperty</code> in <code>EVENT_HEADER</code> are:
+</p>
+<pre>
+#define EVENT_HEADER_PROPERTY_XML               0x0001
+#define EVENT_HEADER_PROPERTY_FORWARDED_XML     0x0002
+#define EVENT_HEADER_PROPERTY_LEGACY_EVENTLOG   0x0004
+</pre>
+<p>
+<code>ETW_BUFFER_CONTEXT</code> is 4 octets long; its structure is described on <a class=away
+href="https://learn.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-etw_buffer_context">Microsoft's
+page for the <code>ETW_BUFFER_CONTEXT</code> structure</a>.
+</p>
+<p>
+<code>ExtendedDataCount</code> is the amount of <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item"><code>EVENT_HEADER_EXTENDED_DATA_ITEM</code></a> items.
+The Extended Data Headers are identical to the one described in Microsoft's documentation, which the exception of the <code>DataPtr</code>. This field points towards an offset relative to the beginning of the <code>EVENT_HEADER</code> instead of an actual pointer.
+<p>
+<code>TlvCount</code> is the amount of <code>ETW_TLV</code> items.
+</p>
+<p>
+<code>PropertiesCount</code> is the amount of <code>ETW_PROPERTY</code> items.
+</p>
+<h4 class="subtitle"><code>ETW_TLV</code> structure</h4>
+<p>
+<code>ETL_TLV</code> defines arbitrary data that is included by the sniffer in the capture process. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                              Type                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Offset                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Length                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+<ul>
+<li>Type: one of the following</li>
+<pre>
+enum ETL_TLV_TYPE {
+    TLV_USER_DATA     = 0,  // Specific event data of the provider; its format is defined by the provider.
+    TLV_MESSAGE       = 1,  // A null-terminated UTF-16LE string that contains the event message string.
+    TLV_PROVIDER_NAME = 2,  // A null-terminated UTF-16LE string that contains the event provider name string.
+};
+</pre>
+<li><code>Offset</code>: refers to an offset relative to the beginning of the EVENT_HEADER.</li>
+<li><code>Length</code>: is the size of the data referred by this TLV.</li>
+</ul>
+For more information about the <code>EventMessage</code> or <code>ProviderName</code> strings, refer to <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/ns-tdh-trace_event_info">TRACE_EVENT_INFO</a>.
+</p>
+<h4 class="subtitle"><code>ETW_PROPERTY</code> structure</h4>
+<p>
+<code>ETW_PROPERTY</code> defines a property by its name (key) and value. It is structured as follows :
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             OFFSET                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|           KEYLENGTH           |          VALUELENGTH          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+It points towards the concatenation of the Key and Value, both as null-terminated UTF-16LE strings without padding in between, as outputed by <a class=away href="https://learn.microsoft.com/en-us/windows/win32/api/tdh/nf-tdh-tdhformatproperty">TdhFormatProperty()</a>. The Offset is from the beginning of the <code>EVENT_HEADER</code>.
+</p>
+</div>
+          </div>
+          <!-- End of LINKTYPE_ETW section -->
+        </div>
+        <!-- END OF PAGE CONTENTS -->
+
+        <!-- FOOTER -->
+        <div id="footer">
+            <p>
+                This web site is &copy; 1999&ndash;2026 The Tcpdump Group
+                (<a href="https://github.com/the-tcpdump-group/tcpdump-htdocs/blob/master/README.md">more
+                information</a>).
+            </p>
+        </div>
+        <!-- END OF FOOTER -->
+
+    </body>
+    <!-- END OF HTML BODY -->
+</html>


### PR DESCRIPTION
Hi everyone,

I have been attempting to improve support for the etwdump reader in Wireshark. It's using `LINKTYPE_ETW` defined here as the link between `etwdump` (windows specific dumper that taps into the ETW sources) and the parser which is directly in Wireshark. (PR https://gitlab.com/wireshark/wireshark/-/merge_requests/24666)

The general idea of ETW is to transmit a bunch of properties and a formatting string, then have the engine render it into a formatted message. Currently the `LINKTYPE_ETW` only transports the fully formatted message. This means that you lose the property names, but also the versability to be able to filter on them, etc.

The current format has many caveats which make it mostly impossible to extend cleanly:
- it has hardcoded 3 fields (user data, message and provider name) arbitrarily and doesn't allow to transport anything else
- it provides no way of transporting the ["Extended Data"](https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item) items, which means it doesn't allow to use any of the capture flags that ETW allows (see the screenshot below in the Wireshark PR)
- it has no versioning which makes it impossible to be backwards compatible

My proposal implemented in the Wireshark PR and this document, is to replace this bunch of hardcoded stuff with TLVs that will allow later extensibility. The use of offsets+length to point to the data items should allow to support anything we might want to add later without breaking again the compatibility (although I'm almost certain no one on earth is storing pcaps of ETW). I really hesitated to add a `Version` field at the top, it's still an option if deemed necessary (and we think that we want to commit to maintaining compatibility).

~~Because this format is basically only used as a Wireshark internal, I *think* that it's fine to simply overwrite it. I'm a bit unsure if it makes sense to try and standardize it here at all (the alternative would be to just say: "this is a Wireshark internal, please see the Wireshark documentation), but since it already exists I'm making this PR to have it up-to-date.~~

Edit: moved this to LINKTYPE_ETW2.


Illustration: the [kind of things you should be able to transport in `LINKTYPE_ETW2`:](https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item)
<img width="596" height="478" alt="image" src="https://github.com/user-attachments/assets/d5914084-b634-4ef4-a8fd-ae15566bb7ba" />

What is your opinion ? Thanks and have a great weekend